### PR TITLE
Don't insert emoji in the middle of a word

### DIFF
--- a/emojify.js
+++ b/emojify.js
@@ -142,9 +142,6 @@
                         return emojiName;
                     }
 
-                    /* Any smiley thats 3 chars long is probably a smiley */
-                    if(m.length > 2) { return success(); }
-
                     /* At the beginning? */
                     if(index === 0) { return success(); }
 
@@ -175,6 +172,7 @@
                     var index = arguments[arguments.length - 2];
                     var input = arguments[arguments.length - 1];
                     var emojiName = validator.validate(matches, index, input);
+
                     if(emojiName) {
                         return replacer(arguments[0], emojiName);
                     }

--- a/tests/string_spec.js
+++ b/tests/string_spec.js
@@ -25,6 +25,12 @@ JS.Test.describe('emojify used with flat strings', function() {
             var result = emojify.replace(text);
             this.assertEqual(' <img title=\':blush:\' alt=\':blush:\' class=\'emoji\' src=\'images/emoji/blush.png\' align=\'absmiddle\' /> ', result);
         });
+
+        this.it('does not insert emoji into the middle of words', function () {
+            var text = "a link for you https://hacks.mozilla.org/2014/06/introducing-the-web-audio-editor-in-firefox-developer-tools/"; // `x-d` appears and might be matched in this string
+            var result = emojify.replace(text);
+            this.assertEqual(text, result);
+        });
     });
 
     this.describe('with multiple emoji beside each other', function() {


### PR DESCRIPTION
Here's a patch that solves a bug I was seeing in my use of emojify.js:

https://github.com/qq99/echoplexus/issues/235 the bug in question

When emojifying a plain old string, sometimes it was inserting emoji mid-word.  This is especially likely in URLs that use hyphens (the one in question was `https://hacks.mozilla.org/2014/06/introducing-the-web-audio-editor-in-firefox-developer-tools/` which has `x-d` in it that got converted)

Making this change doesn't break any tests, as far as I can see
