### PR TITLE
Added gulp bump task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,4 +36,5 @@ If you have rights to publish to npm, do the following first:
 
 - Run `update.sh`. This will update the project with the latest emoji from [emoji-cheat-sheet.com](http://www.emoji-cheat-sheet.com).
 - Run `gulp`
+- Run `gulp bump`
 - Run `npm publish`

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp'),
     $ = require('gulp-load-plugins')(),
-    path = require('path');
+    path = require('path'),
+    inquirer = require('inquirer');
 
 gulp.task('default', ['compile']);
 
@@ -70,4 +71,23 @@ gulp.task('test-node', function(){
         .pipe($.mocha({
             reporter: 'spec'
         }));
+});
+
+gulp.task('bump', function(done){
+    inquirer.prompt({
+        type: 'list',
+        name: 'bump',
+        message: 'What type of bump would you like to do?',
+        choices: ['patch', 'minor', 'major', "don't bump"]
+    }, function(result){
+        if(result.bump === "don't bump"){
+            done();
+            return;
+        }
+
+        gulp.src('./package.json')
+            .pipe($.bump({type: result.bump}))
+            .pipe(gulp.dest('./'))
+            .on('end', done);
+    });
 });

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "gulp-minify-css": "~0.3.11",
     "gulp-image-data-uri": "~0.1.0",
     "gulp-filter": "~1.0.2",
-    "gulp-concat": "~2.4.1"
+    "gulp-concat": "~2.4.1",
+    "inquirer": "~0.8.0",
+    "gulp-bump": "~0.1.11"
   },
   "testling": {
     "html": "tests/browser/browser.html",


### PR DESCRIPTION
Once #95 is merged, I can add a `gulp release` task which cleans the dists, compiles, possibly runs the tests, and bumps. `update.sh` could be added to it too once it's converted.

Closes #89
